### PR TITLE
[FEAT] : Login,Signup 수정, MainActivity,MypageFragment일부 수정. 상세사항 코멘트 참조

### DIFF
--- a/app/src/main/java/com/classic/museo/Fragment/MypageFragment.kt
+++ b/app/src/main/java/com/classic/museo/Fragment/MypageFragment.kt
@@ -1,21 +1,32 @@
 package com.classic.museo.Fragment
 
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import com.classic.museo.MainActivity
 import com.classic.museo.R
+import com.classic.museo.databinding.ActivityMainBinding
+import com.classic.museo.databinding.FragmentMypageBinding
 
 
 class MypageFragment : Fragment() {
-
+    lateinit var binding: FragmentMypageBinding
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        binding = FragmentMypageBinding.inflate(inflater)
+        //로그아웃
+        binding.MypageLogoutButton.setOnClickListener {
+            Log.d("버튼테스트","로그아웃버튼")
+        }
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_mypage, container, false)
+        return binding.root
     }
-
 }

--- a/app/src/main/java/com/classic/museo/LoginActivity.kt
+++ b/app/src/main/java/com/classic/museo/LoginActivity.kt
@@ -27,11 +27,11 @@ class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        val intent= Intent(this,MainActivity::class.java)
 
         //로그인 버튼
 
        binding.btnLogin.setOnClickListener {
-            val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
         }
 
@@ -41,7 +41,6 @@ class LoginActivity : AppCompatActivity() {
                     Log.e("Login", "카카오계정으로 로그인 실패", error)
                 } else if (token != null) {
                     Log.i("Login", "카카오계정으로 로그인 성공 ${token.accessToken}")
-                    val intent= Intent(this,MainActivity::class.java)
                     startActivity(intent)
                 }
             }
@@ -62,6 +61,7 @@ class LoginActivity : AppCompatActivity() {
                         UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
                     } else if (token != null) {
                         Log.i("Login", "카카오톡으로 로그인 성공 ${token.accessToken}")
+                        startActivity(intent)
                     }
                 }
             } else {

--- a/app/src/main/java/com/classic/museo/MainActivity.kt
+++ b/app/src/main/java/com/classic/museo/MainActivity.kt
@@ -10,6 +10,10 @@ import com.classic.museo.Fragment.SearchFragment
 import com.classic.museo.databinding.ActivityMainBinding
 import com.google.android.material.tabs.TabLayoutMediator
 
+//팀 노션 : https://teamsparta.notion.site/3-Museo-72e01c364bd64fa18324fa82dad2b300
+//팀 깃허브 : https://github.com/ProjectMuseo/Museo
+//팀 피그마 : https://www.figma.com/file/TSceoygyttCTT98BGW6Xyf/Final-Project?type=design&node-id=0-1&mode=design&t=Vg6NUqk8kGv7hxaM-0
+
 class MainActivity : AppCompatActivity() {
 
     private lateinit var MainContext : Context

--- a/app/src/main/java/com/classic/museo/SignupActivity.kt
+++ b/app/src/main/java/com/classic/museo/SignupActivity.kt
@@ -5,6 +5,8 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
+import android.widget.Toast
 import com.classic.museo.databinding.ActivitySignupBinding
 import java.util.regex.Pattern
 
@@ -15,6 +17,13 @@ class SignupActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySignupBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        //아이디 유효성 검사(알파벳과 숫자만 허용)
+        fun isValidId(id: String): Boolean {
+            var id = binding.signupEditId.text.toString().trim()
+            val idPattern = "^[a-zA-Z0-9]*\$"
+            return id.matches(idPattern.toRegex())
+        }
 
         binding.signupEditPw2.addTextChangedListener(object : TextWatcher{
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
@@ -57,5 +66,36 @@ class SignupActivity : AppCompatActivity() {
                 }
             }
         })
+        binding.btnSignup2.setOnClickListener {
+            val name = binding.signupEditName.text.toString()
+            val id = binding.signupEditId.text.toString()
+            val pw1 = binding.signupEditPw.text.toString()
+            val pw2 = binding.signupEditPw2.text.toString()
+
+            //아이디 유효성 검사
+            if(!isValidId(id)){
+                Log.d("아이디 유효성 검사","실패")
+                Toast.makeText(this,"아이디는 영문자 및 숫자만 가능합니다",Toast.LENGTH_SHORT).show()
+            } else {
+                Log.d("아이디 유효성 검사","성공")
+                Toast.makeText(this,"아이디가 적합합니다",Toast.LENGTH_SHORT).show()
+            }
+
+            //공백 검사
+            if(name.isEmpty()){
+                Toast.makeText(this,"닉네임을 입력해 주세요",Toast.LENGTH_SHORT).show()
+            }
+            if(id.isEmpty()) {
+                Toast.makeText(this, "아이디를 입력해 주세요", Toast.LENGTH_SHORT).show()
+            }
+            if(pw1.isEmpty()) {
+                Toast.makeText(this, "비밀번호를 입력해 주세요", Toast.LENGTH_SHORT).show()
+            }
+            if(pw2.isEmpty()){
+                Toast.makeText(this,"비밀번호를 다시한번 입력해 주세요",Toast.LENGTH_SHORT).show()
+            } else {
+            Toast.makeText(this,"회원가입 성공",Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 }

--- a/app/src/main/res/drawable/button_background.xml
+++ b/app/src/main/res/drawable/button_background.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!--    배경색[Background Color]-->
+    <solid android:color="#D9D9D9" />
+
+    <!--    테두리 선[Border] 길이 및 색-->
+    <stroke android:width="2dp" android:color="@color/black" />
+
+    <!--    모서리[Corner] 둥글게
+            topRightRadius(위오른쪽), topLeftRadius(위왼쪽)
+            처럼 지정하여 특정 부분만 적용 가능-->
+    <corners android:radius="20dp" />
+
+    <!--    패딩[padding]
+    <padding android:top="5dp" />
+    -->
+
+</shape>

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -143,16 +143,15 @@
             app:layout_constraintStart_toStartOf="@+id/signup_edit_pw2"
             app:layout_constraintTop_toBottomOf="@+id/signup_edit_pw2" />
 
-        <TextView
+        <android.widget.Button
             android:id="@+id/btn_signup2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="35dp"
-            android:layout_marginTop="50dp"
-            android:layout_marginBottom="20dp"
+            android:layout_marginHorizontal="50dp"
+            android:layout_marginTop="20dp"
             android:background="@drawable/login_background"
-            android:gravity="center"
             android:padding="10dp"
+            android:gravity="center"
             android:text="회원가입"
             android:textColor="@color/black"
             android:textSize="20sp"

--- a/app/src/main/res/layout/fragment_mypage.xml
+++ b/app/src/main/res/layout/fragment_mypage.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,5 +11,15 @@
         android:layout_height="match_parent"
         android:text="mypage page"
         android:textSize="30dp"/>
+
+    <Button
+        android:id="@+id/MypageLogoutButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="32dp"
+        android:text="로그아웃"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
기능 변경사항

> LoginActivity
> 1. intent 변수를 override fun onCreate 하단으로 옮겨 준 전역변수로 설정하였습니다.
> 2. 로그인 경우의 수 모두(아이디 로그인, 카카오톡 로그인, 카카오 계정 로그인)에 startActivity(intent)를 넣어 MainActivity로 넘어갈수 있게 만들었습니다.

> SignupActivity
> 1. 알파벳과 숫자만 허용하는 유효성 검사 코드를 추가하였습니다.
> 2. 회원가입 버튼 누를때 아이디 유효성 검사, 공백 검사 코드를 추가하였습니다.

> MainActivity
> 1. 팀 노션, 깃허브, 피그마 링크를 주석으로 추가하였습니다

============= 구 분 선 =============

디자인 수정사항
> SignupActivity
> 회원가입 텍스트버튼을 일반 버튼으로 변경하였습니다

> MypageFragment
> 로그아웃용 버튼 추가.  버튼 테스트용 로그메세지 띄우는 기능만 있습니다