### PR TITLE
[BUG][FEAT](보안상)로그아웃, 로그인 이전 막아놓기, 커뮤니티 수정삭제, 홈 버그 픽스, 카카오 아이디 글 수정 삭제

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="corretto-18" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="corretto-18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/classic/museo/Login/LoginActivity.kt
+++ b/app/src/main/java/com/classic/museo/Login/LoginActivity.kt
@@ -38,18 +38,12 @@ class LoginActivity : AppCompatActivity() {
     private var db = Firebase.firestore
     private lateinit var auth: FirebaseAuth //전역으로 사용할 FirebaseAuth 생성
 
-    init {
-        //로그인화면으로 돌아올경우 모두로그아웃으로 초기화
-        FirebaseAuth.getInstance().signOut()
-        UserApiClient.instance.logout { error ->
-            if (error != null) {
-                Log.e(TAG, "로그아웃 실패. SDK에서 토큰 삭제됨", error)
-            }
-            else {
-                Log.i(TAG, "로그아웃 성공. SDK에서 토큰 삭제됨")
-            }
-        }
+    override fun onResume() {
+        super.onResume()
+    }
 
+    override fun onDestroy() {
+        super.onDestroy()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -84,19 +78,19 @@ class LoginActivity : AppCompatActivity() {
         binding.btnLogin.setOnClickListener {
             //SharedPreferences를 활용한 로그인정보 저장하기
             var checkbox = 0
-            val pref = getSharedPreferences("pref",0)
+            val pref = getSharedPreferences("pref", 0)
             val edit = pref.edit()
-            if(binding.LoginRemember.isChecked){
+            if (binding.LoginRemember.isChecked) {
                 //로그인정보 저장 체크
                 checkbox = 1
-                edit.putInt("CheckBox",checkbox)
+                edit.putInt("CheckBox", checkbox)
                 edit.putString("ID", binding.editId.text.toString())
                 edit.putString("PW", binding.editPw.text.toString())
                 edit.apply()
             } else {
                 //로그인정보 저장 해제
                 checkbox = 0
-                edit.putInt("CheckBox",checkbox)
+                edit.putInt("CheckBox", checkbox)
                 edit.putString("ID", "")
                 edit.putString("PW", "")
                 edit.apply()
@@ -136,12 +130,12 @@ class LoginActivity : AppCompatActivity() {
             }
         }
         //로그인정보 기억하기 체크했을때 값 받아오기
-        val pref = getSharedPreferences("pref",0)
-        binding.editId.setText(pref.getString("ID",""))
-        binding.editPw.setText(pref.getString("PW",""))
-        if(pref.getInt("CheckBox",0) == 1){
+        val pref = getSharedPreferences("pref", 0)
+        binding.editId.setText(pref.getString("ID", ""))
+        binding.editPw.setText(pref.getString("PW", ""))
+        if (pref.getInt("CheckBox", 0) == 1) {
             binding.LoginRemember.isChecked = true
-        } else{
+        } else {
             binding.LoginRemember.isChecked = false
         }
 
@@ -152,6 +146,7 @@ class LoginActivity : AppCompatActivity() {
         //파이어베이스에 유저 상태가 있어야 다음 페이지로 넘어갈 수 있음
         if (user != null) {
             val intent = Intent(this, MainActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             startActivity(intent)
         }
     }
@@ -159,6 +154,7 @@ class LoginActivity : AppCompatActivity() {
     //카카오 로그인
     fun kakaoSingUp() {
         val intent = Intent(this, MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         binding.kakaoLogin.setOnClickListener {
             val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
                 if (error != null) {

--- a/app/src/main/java/com/classic/museo/MainActivity.kt
+++ b/app/src/main/java/com/classic/museo/MainActivity.kt
@@ -1,9 +1,12 @@
 package com.classic.museo
 
 import android.annotation.SuppressLint
+import android.content.ContentValues
 import android.content.Context
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.WindowInsets
@@ -14,12 +17,15 @@ import androidx.navigation.NavHost
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupActionBarWithNavController
+import com.classic.museo.Login.LoginActivity
 import com.classic.museo.databinding.ActivityMainBinding
 import com.classic.museo.home.HomeFragment
 import com.classic.museo.itemPage.MypageFragment
 import com.classic.museo.itemPage.search.SearchFragment
 import com.classic.museo.itemPage.CommunityFragment
 import com.google.android.material.tabs.TabLayoutMediator
+import com.google.firebase.auth.FirebaseAuth
+import com.kakao.sdk.user.UserApiClient
 
 
 //팀 노션 : https://teamsparta.notion.site/3-Museo-72e01c364bd64fa18324fa82dad2b300
@@ -46,6 +52,19 @@ class MainActivity : AppCompatActivity() {
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.menu, menu)
         return true
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        FirebaseAuth.getInstance().signOut()
+        UserApiClient.instance.logout { error ->
+            if (error != null) {
+                Log.e(ContentValues.TAG, "로그아웃 실패. SDK에서 토큰 삭제됨", error)
+            }
+            else {
+                Log.i(ContentValues.TAG, "로그아웃 성공. SDK에서 토큰 삭제됨")
+            }
+        }
     }
 
     //바텀 네비게이션 기능

--- a/app/src/main/java/com/classic/museo/home/HomeAdapter2.kt
+++ b/app/src/main/java/com/classic/museo/home/HomeAdapter2.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.classic.museo.itemPage.DetailActivity
 import com.classic.museo.R
 import com.classic.museo.data.Record
@@ -21,6 +22,7 @@ class HomeAdapter2(var subject: String, val hContext: Context) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     var museoData = mutableListOf<Record>()
     private var intent = Intent()
+    private val glide: RequestManager = Glide.with(hContext)
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val view =
             RecyclerviewItem2Binding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -74,7 +76,7 @@ class HomeAdapter2(var subject: String, val hContext: Context) :
 
         fun bind(pos: Int) {
             binding.textView2.text = museoData[pos].fcltyNm
-            binding.textView4.text="update : "+museoData[pos].referenceDate
+            binding.textView4.text = "update : " + museoData[pos].referenceDate
             category(museoData[pos].fcltyNm)
         }
 
@@ -93,16 +95,16 @@ class HomeAdapter2(var subject: String, val hContext: Context) :
             var category = ""
             if (subject == "이색 박물관") {
                 category = "unique"
-            }else if (subject == "생물 박물관") {
+            } else if (subject == "생물 박물관") {
                 category = "Biology"
-            }else if (subject == "과학 박물관") {
+            } else if (subject == "과학 박물관") {
                 category = "science"
             }
             val storageReference = storageRef.child("${category}/${text}.png")
-
             storageReference.downloadUrl.addOnSuccessListener { uri ->
+
                 val imageURL = uri!!
-                Glide.with(hContext)
+                glide
                     .load(imageURL)
                     .into(binding.imageView2)
                 Log.e("이미지", "${imageURL}")

--- a/app/src/main/java/com/classic/museo/home/HomeFragment.kt
+++ b/app/src/main/java/com/classic/museo/home/HomeFragment.kt
@@ -56,10 +56,13 @@ class HomeFragment : Fragment() {
         return binding.root
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+    }
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         hContext = context
-
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/classic/museo/itemPage/Community/CommunityAdapter.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/Community/CommunityAdapter.kt
@@ -59,6 +59,7 @@ class CommunityAdapter(private val context: Context) :
         }
 
         fun bind(pos: Int) {
+            Log.e("checkone","${review[pos].title}-${pos}")
             binding.textCommunityTitle.text = review[pos].title
             binding.communityNickname.text = review[pos].NickName
             binding.communityId.text = review[pos].UserId

--- a/app/src/main/java/com/classic/museo/itemPage/Community/CommunityFragment.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/Community/CommunityFragment.kt
@@ -51,6 +51,8 @@ class CommunityFragment : Fragment() {
     }
 
     private fun postingLoad(){
+        loadItems.clear()
+        idItems.clear()
         adapter.clearItem()
         val query=db.collection("post")
         query.orderBy("date", Query.Direction.DESCENDING)

--- a/app/src/main/java/com/classic/museo/itemPage/Community/CommunityPlusActivity.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/Community/CommunityPlusActivity.kt
@@ -49,6 +49,7 @@ class CommunityPlusActivity : AppCompatActivity() {
         binding.communityPlusCancle.setOnClickListener{
             finish()
         }
+        //게시버튼
         binding.communityPlus.setOnClickListener{
 
             if(binding.communityPlusTitle.text.isEmpty()||binding.communityPlusEdittext.text.isEmpty()||

--- a/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/MypageLogoutDialog.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/MypageLogoutDialog.kt
@@ -43,6 +43,7 @@ class MypageLogoutDialog : DialogFragment() {
                 FirebaseAuth.getInstance().signOut()
                 Toast.makeText(activity,"회원 로그아웃 성공!",Toast.LENGTH_SHORT).show()
                 val backtomain = Intent(activity, LoginActivity::class.java)
+                backtomain.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 startActivity(backtomain)
             }else {
                 // 로그아웃
@@ -53,6 +54,7 @@ class MypageLogoutDialog : DialogFragment() {
                     else {
                         Log.i(TAG, "로그아웃 성공. SDK에서 토큰 삭제됨")
                         val backtomain = Intent(activity, LoginActivity::class.java)
+                        backtomain.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                         startActivity(backtomain)
                         Toast.makeText(context,"회원(카카오)로그아웃 성공!",Toast.LENGTH_SHORT).show()
                     }

--- a/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/MypageWritten.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/MypageWritten.kt
@@ -33,7 +33,7 @@ class MypageWritten : AppCompatActivity() {
         //카카오 로그인 유저 게시물
         UserApiClient.instance.me { user, error ->
             if (error != null) {
-                Log.e("에러", "사용자 정보 요청 실패", error)
+                Log.e("일반 로그인", "사용자 정보 요청 실패", error)
             } else if (user != null) {
                 kUid = user.id.toString()
 


### PR DESCRIPTION
## 작업
> **(보안상)로그아웃, 로그인 이전 막아놓기, 커뮤니티 수정삭제, 홈 버그 픽스, 카카오 아이디 글 수정 삭제**
## 작업 상세내용
- [x] 로그아웃,로그인 이전 막아놓기 (intent에 flag)
- [x] 커뮤니티 수정삭제 버그 픽스
- [x] 홈 glide.with가 호출되는 중에 액티비티가 파괴되면서 오류 발생, 해결
- [x] 카카오 아이디 글 수정 삭제
## 참고사항
[파이어베이스 참고 문서](https://firebase.google.com/docs/database?hl=ko)

close #55 