### PR TITLE
[FEAT] : ⚙️: 즐겨찾기 추가 삭제 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="corretto-18" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/classic/museo/data/LikeDTO.kt
+++ b/app/src/main/java/com/classic/museo/data/LikeDTO.kt
@@ -1,0 +1,16 @@
+package com.classic.museo.data
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class LikeDTO(
+    val title:String,
+    val address:String,
+    val category:String,
+    val museum: String,
+) : Parcelable {
+    constructor() : this("","","","")
+}
+
+

--- a/app/src/main/java/com/classic/museo/data/MyPostDTO.kt
+++ b/app/src/main/java/com/classic/museo/data/MyPostDTO.kt
@@ -1,0 +1,7 @@
+package com.classic.museo.data
+
+data class MyPostDTO(
+    val aTitle:String,
+    val aSub:String
+) {
+}

--- a/app/src/main/java/com/classic/museo/itemPage/Community/CommunityDetailActivity.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/Community/CommunityDetailActivity.kt
@@ -17,7 +17,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.classic.museo.R
 import com.classic.museo.data.CommunityDTO
 import com.classic.museo.data.Record
-import com.classic.museo.itemPage.MypageInnerActivity.DummyItem
 import com.classic.museo.databinding.ActivityCommunityDetailBinding
 import com.classic.museo.itemPage.MypageInnerActivity.WrittenAdapter
 import com.google.firebase.auth.FirebaseAuth

--- a/app/src/main/java/com/classic/museo/itemPage/Community/CommunityDetailItem.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/Community/CommunityDetailItem.kt
@@ -6,10 +6,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.TextView
-import com.classic.museo.itemPage.MypageInnerActivity.DummyItem
 import com.classic.museo.R
+import com.classic.museo.data.MyPostDTO
 
-class CommunityDetailItem(val mContext: CommunityDetailActivity, val mItems: MutableList<DummyItem>) : BaseAdapter() {
+class CommunityDetailItem(val mContext: CommunityDetailActivity, val mItems: MutableList<MyPostDTO>) : BaseAdapter() {
 
     override fun getCount(): Int {
         return mItems.size
@@ -30,7 +30,7 @@ class CommunityDetailItem(val mContext: CommunityDetailActivity, val mItems: Mut
         if (convertView == null) convertView = LayoutInflater.from(parent?.context)
             .inflate(R.layout.mypost_item, parent, false)
 
-        val item: DummyItem = mItems[position]
+        val item: MyPostDTO = mItems[position]
 
         val tv_title = convertView?.findViewById<TextView>(R.id.itemTitle)
         val tv_sub = convertView?.findViewById<TextView>(R.id.itemSub)

--- a/app/src/main/java/com/classic/museo/itemPage/DetailActivity.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/DetailActivity.kt
@@ -4,26 +4,37 @@ package com.classic.museo.itemPage
 import android.content.Intent
 import android.os.Bundle
 import android.text.util.Linkify
-import android.text.util.Linkify.TransformFilter
+import android.util.Log
 import android.view.View
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.classic.museo.R
 import com.classic.museo.data.Record
 import com.classic.museo.databinding.ActivityDetailBinding
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldPath
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import net.daum.mf.map.api.MapPOIItem
 import net.daum.mf.map.api.MapPoint
 import net.daum.mf.map.api.MapView
-import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 
 class DetailActivity : AppCompatActivity() {
+
     lateinit var binding: ActivityDetailBinding
+    private var db = Firebase.firestore
+    private var auth: FirebaseAuth? = null
+    private var subId = ""
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityDetailBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
 
         //뒤로가기 버튼
         binding.dtBack.setOnClickListener {
@@ -38,14 +49,16 @@ class DetailActivity : AppCompatActivity() {
 
         //공공데이터 받아오기
         museoInfo()
+        //즐겨찾기 버튼
+        likeBtn()
 
     }
 
     //카카오 맵
-    fun kakaoMap(){
+    fun kakaoMap() {
         val mapView = MapView(this)
         binding.kakaoMap.addView(mapView)
-        val a=intent.getParcelableExtra<Record>("museumData")!!
+        val a = intent.getParcelableExtra<Record>("museumData")!!
 
 
         //위도 데이터
@@ -72,7 +85,7 @@ class DetailActivity : AppCompatActivity() {
 
     //공유버튼 기능
     private fun share() {
-        val a=intent.getParcelableExtra<Record>("museumData")!!
+        val a = intent.getParcelableExtra<Record>("museumData")!!
         binding.dtShare.setOnClickListener {
 
             val shareIntent = Intent().apply {
@@ -86,9 +99,10 @@ class DetailActivity : AppCompatActivity() {
             startActivity(Intent.createChooser(shareIntent, null))
         }
     }
+
     //공공api데이터 가져오기
     fun museoInfo() {
-        val a=intent.getParcelableExtra<Record>("museumData")!!
+        val a = intent.getParcelableExtra<Record>("museumData")!!
         //시설명
         binding.dtTitle.text = a.fcltyNm
         //운영기관전화번호
@@ -100,7 +114,8 @@ class DetailActivity : AppCompatActivity() {
         //휴관정보
         binding.closeDayTx.text = a.rstdeInfo
         //이용시간
-        binding.hoursuseTx.text = "${a.weekdayOperOpenHhmm}~${a.weekdayOperColseHhmm} (공휴일 ${a.holidayOperOpenHhmm} ~ ${a.holidayCloseOpenHhmm})"
+        binding.hoursuseTx.text =
+            "${a.weekdayOperOpenHhmm}~${a.weekdayOperColseHhmm} (공휴일 ${a.holidayOperOpenHhmm} ~ ${a.holidayCloseOpenHhmm})"
         //관람료 기타정보(입장료)
         binding.moneyTx.text = "${a.adultChrge}원 ${a.etcChrgeInfo}"
         //운영홈페이지
@@ -116,9 +131,126 @@ class DetailActivity : AppCompatActivity() {
 
         dt_title.text = text
 
-        val mTransform = Linkify.TransformFilter(){ _, _ -> ""
+        val transform = Linkify.TransformFilter() { _, _ ->
+            ""
         }
         val pattern = Pattern.compile(a.fcltyNm)    //링크 걸 단어를 맞게 설정해 줘야함
-        Linkify.addLinks(dt_title, pattern, a.homepageUrl, null, mTransform)
+        Linkify.addLinks(dt_title, pattern, a.homepageUrl, null, transform)
+    }
+
+    //즐겨찾기 버튼
+    fun likeBtn() {
+        binding.dtLike.setOnClickListener {
+
+            val a = intent.getParcelableExtra<Record>("museumData")!!   //박물관 정보
+            val title = binding.dtTitle.text.toString()
+            val address = binding.dtAddress.text.toString()
+            val category = a.fcltyType
+            var museum = ""
+            if (binding.dtTitle.text.endsWith("미술관")) {
+                museum = "미술관"
+            } else {
+                museum = "박물관"
+            }
+
+            val db = FirebaseFirestore.getInstance()
+            val auth = FirebaseAuth.getInstance()
+
+            // 현재 로그인한 사용자의 UID 가져오기
+            val currentUser = auth.currentUser
+            val uid = currentUser?.uid
+
+            db.collection("museoInfo")
+                .whereEqualTo("fcltyNm", a.fcltyNm)
+                .get()
+                .addOnSuccessListener { documents ->
+                    for (document in documents) {
+
+                        //firestor 박물관별 문서id 가져오기
+                        subId = document.id
+                        Log.e("asd", subId)
+                    }
+                }
+                .addOnFailureListener { exception ->
+                    Log.e("qwe", "Error getting documents: ", exception)
+                }
+
+            db.collection("users")
+                .document("$uid")
+                .collection("myLike")
+                .get()
+                .addOnSuccessListener { documents ->
+                    for (document in documents) {
+                        val subcollectionId = document.id
+                        Log.e("dd", subcollectionId)
+
+                        val subcollectionRef = db.collection("users")
+                            .document("$uid")
+                            .collection("myLike")
+                        Log.e("asd", subId)
+
+                        // 중복을 확인할 문서 ID가 이미 존재하는지 검사
+                        subcollectionRef.whereEqualTo(FieldPath.documentId(), subId)
+                            .get()
+                            .addOnCompleteListener { task ->
+                                if (task.isSuccessful) {
+                                    val querySnapshot = task.result
+
+                                    if (querySnapshot != null) {
+                                        if (!querySnapshot.isEmpty) {
+                                            // 중복되는 문서 ID가 존재할 때
+                                            Log.e("성공맞냐", "${subId}")
+
+                                            //데이터 삭제
+                                            val collectionPath =
+                                                "users/$uid/myLike"
+                                            subcollectionRef.whereEqualTo(FieldPath.documentId(), subId)
+                                            db.collection(collectionPath)
+                                                .document(subId)
+                                                .delete()
+                                                .addOnSuccessListener { Log.d("성공", "DocumentSnapshot successfully deleted!") }
+                                                .addOnFailureListener { e -> Log.w("실패", "Error deleting document", e) }
+
+                                        } else {
+                                            // 중복되는 문서 ID가 존재하지 않을 때
+                                            Log.e("실패맞냐", "${subId}")
+
+                                            //데이터 생성
+                                            if (uid != null) {
+                                                val collectionPath =
+                                                    "users/$uid/myLike"
+                                                // 서브컬렉션에 새 문서 추가
+                                                val data = hashMapOf(
+                                                    "title" to title,
+                                                    "address" to address,
+                                                    "category" to category,
+                                                    "museum" to museum,
+                                                )
+                                                db.collection(collectionPath)
+                                                    .document(subId)
+                                                    .set(data)
+                                                    .addOnSuccessListener { documentReference ->
+                                                        Log.e("성공zzz", "${documentReference}")
+                                                    }
+                                                    .addOnFailureListener { e ->
+                                                        Log.e("실패eee", "$e")
+                                                    }
+                                            } else {
+                                                Toast.makeText(
+                                                    this,
+                                                    "사용자가 로그인하지 않았습니다..",
+                                                    Toast.LENGTH_SHORT
+                                                ).show()
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    // 쿼리를 실행하는 동안 오류가 발생했을 때
+                                    println("쿼리를 실행하는 동안 오류가 발생했습니다: ${task.exception}")
+                                }
+                            }
+                    }
+                }
+        }
     }
 }

--- a/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/LikeAdapter.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/LikeAdapter.kt
@@ -1,43 +1,73 @@
 package com.classic.museo.itemPage.MypageInnerActivity
 
-import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import com.classic.museo.R
+import com.classic.museo.data.AnnouncementDTO
+import com.classic.museo.data.LikeDTO
+import com.classic.museo.data.MyPostDTO
+import com.classic.museo.databinding.ActivityMypageLikeItemBinding
+import com.classic.museo.databinding.AnnouncementItemBinding
+import com.classic.museo.itemPage.announcement.AnnouncementAdapter
+import com.classic.museo.itemPage.announcement.AnnouncementDetailActivity
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 
-class LikeAdapter(val mContext: MypageLike, val mItems: MutableList<DummyItem>) : BaseAdapter() {
+class LikeAdapter(val mItems: MutableList<LikeDTO>,
+                  val context: Context,val likeId:MutableList<String>) :
+    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    override fun getCount(): Int {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val binding =
+            ActivityMypageLikeItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        return likeViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int {
         return mItems.size
     }
 
-    override fun getItem(position: Int): Any {
-        return mItems[position]
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        (holder as likeViewHolder).bind(position)
     }
 
-    override fun getItemId(position: Int): Long {
-        return position.toLong()
-    }
 
-    @SuppressLint("SetTextI18n")
-    override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View? {
+    inner class likeViewHolder(private val binding: ActivityMypageLikeItemBinding) :
+        RecyclerView.ViewHolder(binding.root), View.OnClickListener {
 
-        var convertView = convertView
-        if (convertView == null) convertView = LayoutInflater.from(parent?.context)
-            .inflate(R.layout.mypost_item, parent, false)
+        var detailPage = binding.root
 
-        val item: DummyItem = mItems[position]
+        init {
+            detailPage.setOnClickListener(this)
+        }
 
-        val tv_title = convertView?.findViewById<TextView>(R.id.itemTitle)
-        val tv_sub = convertView?.findViewById<TextView>(R.id.itemSub)
+        fun bind(position: Int){
+            binding.likeTitle.text = mItems[position].title
+            binding.likeAddress.text = mItems[position].address
+            binding.likeCategory.text = mItems[position].category
+            binding.likeMuseum.text = mItems[position].museum
+        }
 
+        override fun onClick(v: View?) {
+            val position = bindingAdapterPosition.takeIf { it != RecyclerView.NO_POSITION } ?: return
+            val intent = Intent(context, MypageLike::class.java)
+            intent.apply {
+                //detail에 데이터 보내주기
+                putExtra("likeData",mItems[position])
+                putExtra("documentID",likeId[position])
+            }
+            context.startActivity(intent)
+        }
 
-        tv_title?.text = item.aTitle
-        tv_sub?.text = item.aSub
-
-        return convertView
     }
 }

--- a/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/MypageLike.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/MypageInnerActivity/MypageLike.kt
@@ -1,27 +1,76 @@
 package com.classic.museo.itemPage.MypageInnerActivity
 
+import android.content.ContentValues
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import com.classic.museo.data.AnnouncementDTO
+import com.classic.museo.data.CommunityDTO
+import com.classic.museo.data.LikeDTO
 import com.classic.museo.databinding.ActivityMypageLikeBinding
+import com.classic.museo.itemPage.announcement.AnnouncementAdapter
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.google.gson.GsonBuilder
 
 class MypageLike : AppCompatActivity() {
-    lateinit var binding: ActivityMypageLikeBinding
+
+    private lateinit var binding: ActivityMypageLikeBinding
+    private lateinit var adapter : LikeAdapter
+    private lateinit var gridLayoutManager: StaggeredGridLayoutManager
+    private var db = Firebase.firestore
+    private val gson = GsonBuilder().create()
+    private val IdItems = mutableListOf<String>()
+    private val loadItem = mutableListOf<LikeDTO>()
+    private var auth: String? = null
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
+
         super.onCreate(savedInstanceState)
         binding = ActivityMypageLikeBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
-        //더미데이터
-        val dummy = mutableListOf<DummyItem>()
-        dummy.add(DummyItem("Like 테스트 제목1","테스트 내용1"))
-        dummy.add(DummyItem("Like 테스트 제목2","테스트 내용2"))
-        dummy.add(DummyItem("Like 테스트 제목3","테스트 내용3"))
-        dummy.add(DummyItem("Like 테스트 제목4","테스트 내용4"))
-        binding.MypageInnerView.adapter = LikeAdapter(this,dummy)
+        auth = FirebaseAuth.getInstance().currentUser?.uid
+        Log.e("qq","$auth")
 
-        binding.MypageInnerBack.setOnClickListener {
+        //파이어스토어 인스턴스 초기화
+        db = FirebaseFirestore.getInstance()
+
+        //뒤로가기
+        binding.MylikeBack.setOnClickListener {
             finish()
         }
+
+
+        db.collection("users")
+            .document("$auth")
+            .collection("myLike")
+            .get()
+            .addOnSuccessListener { documents ->
+                for (document in documents) {
+                    var gson = GsonBuilder().create()
+                    val value = gson.toJson(document.data)
+                    val documentId = document.id
+                    val result = gson.fromJson(value, LikeDTO::class.java)
+                    IdItems.add(documentId)
+                    loadItem.add(result)
+                }
+                if (loadItem.isEmpty()) {
+                    Toast.makeText(this, "즐겨찾기가 없습니다.", Toast.LENGTH_SHORT).show()
+                }
+                binding.favoritesRv.adapter = LikeAdapter(loadItem, this, IdItems)
+                binding.favoritesRv.layoutManager = LinearLayoutManager(this)
+            }
+            .addOnFailureListener { exception ->
+                Log.w(ContentValues.TAG, "Error getting documents: ", exception)
+            }
     }
+
 }

--- a/app/src/main/java/com/classic/museo/itemPage/announcement/AnnouncementAdapter.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/announcement/AnnouncementAdapter.kt
@@ -21,7 +21,11 @@ class AnnouncementAdapter(private val context: Context) :
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val binding =
-            AnnouncementItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            AnnouncementItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
         return AnnouncementViewHolder(binding)
     }
 

--- a/app/src/main/res/drawable/like_border.xml
+++ b/app/src/main/res/drawable/like_border.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:left="0dp">
+        <shape android:shape="rectangle" >
+            <stroke
+                android:width="1dp"
+                android:color="#000000" />	<!--테두리 색-->
+            <corners android:radius="10dp" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/app/src/main/res/layout/activity_mypage_like.xml
+++ b/app/src/main/res/layout/activity_mypage_like.xml
@@ -6,78 +6,48 @@
     android:layout_height="match_parent"
     tools:context=".itemPage.MypageInnerActivity.MypageLike">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraintLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        tools:layout_editor_absoluteX="1dp"
-        tools:layout_editor_absoluteY="1dp">
+        android:layout_height="60dp"
+        android:background="#D8B674"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
 
-            <ImageButton
-                android:id="@+id/MypageInnerBack"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                android:src="@drawable/back"
-                android:background="@android:color/transparent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <ImageView
-                android:id="@+id/imageView3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@drawable/museo" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-        <View
-            android:id="@+id/view2"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/black"
-            android:layout_marginTop="5dp"/>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <TextView
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
-
-            <TextView
-                android:id="@+id/MypageInnerTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="4dp"
-                android:layout_marginBottom="4dp"
-                android:text="좋아요"
-                android:textSize="30dp"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <View
-            android:id="@+id/view6"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
+            android:layout_height="wrap_content"
+            android:text="즐겨찾기"
+            android:textColor="@color/white"
+            android:textSize="30dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+        <ImageView
+            android:id="@+id/Mylike_back"
+            android:layout_width="25dp"
+            android:layout_height="25dp"
+            android:layout_marginLeft="20dp"
             android:layout_marginTop="5dp"
-            android:background="@color/black" />
+            android:src="@drawable/back"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-        <ListView
-            android:id="@+id/MypageInnerView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/favorites_rv"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        tools:listitem="@layout/activity_mypage_like_item"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/constraintLayout" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_mypage_like_item.xml
+++ b/app/src/main/res/layout/activity_mypage_like_item.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+
+    <TextView
+        android:id="@+id/like_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="24dp"
+        android:text="온양민속박물관"
+        android:layout_margin="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/like_address"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="강원특별자치도 춘천시 우석로 70"
+        android:layout_marginTop="15dp"
+        android:layout_marginLeft="20dp"
+        android:textSize="14dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/like_title" />
+
+    <TextView
+        android:id="@+id/like_category"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="15dp"
+        android:text="국립"
+        android:textSize="14dp"
+        android:padding="5dp"
+        android:background="@drawable/like_border"
+        app:layout_constraintBottom_toBottomOf="@+id/like_title"
+        app:layout_constraintStart_toEndOf="@+id/like_title"
+        app:layout_constraintTop_toTopOf="@+id/like_title" />
+
+    <TextView
+        android:id="@+id/like_museum"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="박물관"
+        android:textSize="14dp"
+        android:background="@drawable/like_border"
+        android:padding="5dp"
+        android:layout_marginLeft="10dp"
+        app:layout_constraintBottom_toBottomOf="@+id/like_category"
+        app:layout_constraintStart_toEndOf="@+id/like_category"
+        app:layout_constraintTop_toTopOf="@+id/like_category" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#D4D4D4"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toBottomOf="@+id/like_address"
+        tools:layout_editor_absoluteX="-25dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_mypage.xml
+++ b/app/src/main/res/layout/fragment_mypage.xml
@@ -134,7 +134,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:gravity="center_vertical"
-                    android:text="　좋아요"
+                    android:text="　즐겨찾기"
                     android:textSize="20dp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
##목적

사용자별로 즐겨찾기 한 항목을 사용자들에게 보여준다.
##작업상세내용

 사용자가 즐겨찾기를 누르고 다시 한번 클릭 시 즐겨찾기 제거
 즐겨찾기 DB를 설계한다.
 즐겨찾기 항목들을 여러개 보여주기 위해 리사이클러뷰를 사용해 데이터를 보여준다.
 사용자별 즐겨찾기 데이터는 DB상에서 처리하도록 만들었다.

close #61 