### PR TITLE
[FEAT] : 비회원 로그인 기능 추가

### DIFF
--- a/app/src/main/java/com/classic/museo/Login/LoginActivity.kt
+++ b/app/src/main/java/com/classic/museo/Login/LoginActivity.kt
@@ -40,6 +40,7 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        login()
     }
 
     override fun onDestroy() {
@@ -61,6 +62,12 @@ class LoginActivity : AppCompatActivity() {
 
         //로그인 버튼
         login()
+
+        //비회원 로그인
+        binding.nonLogin.setOnClickListener {
+            val non_login = Intent(this, MainActivity::class.java)
+            startActivity(non_login)
+        }
 
         //카카오 로그인
         kakaoSingUp()

--- a/app/src/main/java/com/classic/museo/itemPage/Community/CommunityDetailActivity.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/Community/CommunityDetailActivity.kt
@@ -16,6 +16,7 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
@@ -210,9 +211,9 @@ class CommunityDetailActivity() : AppCompatActivity() {
             alertDialog.window?.attributes?.windowAnimations = R.style.DialogAnimation
             alertDialog.window?.setBackgroundDrawableResource(R.drawable.community_dialog_shape)
 
-            val btnEdit = dialogView.findViewById<Button>(R.id.dialog_edit)
-            val btnDelete = dialogView.findViewById<Button>(R.id.dialog_delete)
-            val btnCancel = dialogView.findViewById<Button>(R.id.dialog_cancel)
+            val btnEdit = dialogView.findViewById<ConstraintLayout>(R.id.dialog_edit)
+            val btnDelete = dialogView.findViewById<ConstraintLayout>(R.id.dialog_delete)
+            val btnCancel = dialogView.findViewById<ConstraintLayout>(R.id.dialog_cancel)
 
             //다이얼로그 수정버튼 클릭
             btnEdit.setOnClickListener {

--- a/app/src/main/java/com/classic/museo/itemPage/Community/CommunityFragment.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/Community/CommunityFragment.kt
@@ -10,12 +10,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import com.classic.museo.Login.LoginActivity
+import com.classic.museo.Login.SignupActivity
+import com.classic.museo.MainActivity
 import com.classic.museo.itemPage.Community.CommunityPlusActivity
 import com.classic.museo.data.CommunityDTO
 import com.classic.museo.databinding.FragmentCommunityBinding
 import com.classic.museo.itemPage.Community.CommunityAdapter
 import com.classic.museo.itemPage.Community.CommunityDetailActivity
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -35,6 +41,7 @@ class CommunityFragment : Fragment() {
     private var idItems=mutableListOf<String>()
     private var gson= GsonBuilder().create()
     private var loadItems= mutableListOf<CommunityDTO>()
+    private var auth: FirebaseAuth? = null
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -145,6 +152,8 @@ class CommunityFragment : Fragment() {
         //새글추가 버튼 맨 앞으로 보내기
         binding.communityBtnPlus.bringToFront()
 
+        nonLogin()
+
         return binding.root
     }
 
@@ -154,6 +163,29 @@ class CommunityFragment : Fragment() {
         adapter = CommunityAdapter(communityContext)
         binding.recyclerView2.adapter = adapter
         binding.recyclerView2.itemAnimator = null
+    }
+
+    private fun nonLogin(){
+        auth = Firebase.auth
+        val currentUser = auth?.currentUser
+
+        if(currentUser == null){
+            val loginBuilder = AlertDialog.Builder(communityContext)
+            loginBuilder.setTitle("로그인이 필요한 서비스입니다.")
+            loginBuilder.setMessage("로그인 하시겠습니까?")
+
+            loginBuilder.setPositiveButton("확인"){dialog, _ ->
+                val loginIntent = Intent(communityContext, LoginActivity::class.java)
+                loginIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                startActivity(loginIntent)
+            }
+            loginBuilder.setNegativeButton("취소"){dialog,_ ->
+                val cancelIntent = Intent(communityContext, MainActivity::class.java)
+                startActivity(cancelIntent)
+            }
+            loginBuilder.setCancelable(false)
+            loginBuilder.show()
+        }
     }
 
 

--- a/app/src/main/java/com/classic/museo/itemPage/MypageFragment.kt
+++ b/app/src/main/java/com/classic/museo/itemPage/MypageFragment.kt
@@ -1,6 +1,7 @@
 package com.classic.museo.itemPage
 
 import android.content.ContentValues
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -10,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import com.bumptech.glide.Glide
+import com.classic.museo.Login.LoginActivity
 import com.classic.museo.R
 import com.classic.museo.itemPage.MypageInnerActivity.MypageLike
 import com.classic.museo.itemPage.MypageInnerActivity.MypageLogoutDialog
@@ -19,6 +21,7 @@ import com.classic.museo.databinding.FragmentMypageBinding
 import com.classic.museo.itemPage.Community.CommunityDetailActivity
 import com.classic.museo.itemPage.announcement.AnnouncementActivity
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.kakao.sdk.user.UserApiClient
@@ -27,10 +30,17 @@ import com.kakao.sdk.user.UserApiClient
 class MypageFragment : Fragment() {
 
     lateinit var binding: FragmentMypageBinding
+    private lateinit var mypageContext: Context
     private var db = Firebase.firestore
     private val UserList = mutableListOf<Users>()
     private var uid : String? = null
+    private var auth: FirebaseAuth? = null
 
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        mypageContext = context
+    }
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -51,6 +61,9 @@ class MypageFragment : Fragment() {
 
         //firestore에서 로그인한 회원 닉네임 보여주기
         NickName()
+
+        //비회원 로그인시 로그인 페이지 보여주기
+        nonLogin()
 
 //        //커뮤니티 디테일 액티비티로 넘어가는 임시 코드
 //        binding.tempbtn.setOnClickListener {
@@ -136,6 +149,23 @@ class MypageFragment : Fragment() {
             //공지사항 페이지는 아직 없으므로 기능은 미구현
             val announcement = Intent(activity,AnnouncementActivity::class.java)
             startActivity(announcement)
+        }
+    }
+
+    //비회원 로그인시
+    fun nonLogin(){
+        auth = Firebase.auth
+        val currentUser = auth?.currentUser
+
+        if(currentUser == null){
+            binding.MypageSingup.visibility = View.VISIBLE
+            binding.MypageLogout.visibility = View.GONE
+
+            binding.MypageSingup.setOnClickListener{
+                val loginIntent = Intent(mypageContext, LoginActivity::class.java)
+                loginIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                startActivity(loginIntent)
+            }
         }
     }
 }

--- a/app/src/main/res/layout/community_dialog.xml
+++ b/app/src/main/res/layout/community_dialog.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dialog_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -8,37 +9,80 @@
     android:background="@drawable/community_dialog_shape"
     android:orientation="vertical">
 
-        <android.widget.Button
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/dialog_edit"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
-            android:text="수정"
-            android:background="#F5EBEB"
-            android:textSize="17sp"
-            android:textStyle="bold"/>
+            android:padding="15dp"
+            android:orientation="horizontal">
 
-        <android.widget.Button
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="수정"
+                    android:textSize="17sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="5dp"
+            android:background="#D9D9D9" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/dialog_delete"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:layout_marginHorizontal="20dp"
-            android:text="삭제"
-            android:background="#D5B4B4"
-            android:textSize="17sp"
-            android:textStyle="bold"/>
+            android:padding="15dp"
+            android:orientation="horizontal">
 
-        <android.widget.Button
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="삭제"
+                    android:textSize="17sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="5dp"
+            android:background="#D9D9D9" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/dialog_cancel"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:layout_marginHorizontal="20dp"
-            android:text="취소"
-            android:background="#AE8D8D"
-            android:textSize="17sp"
-            android:textStyle="bold"/>
+            android:padding="15dp"
+            android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="취소"
+                    android:textSize="17sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_mypage.xml
+++ b/app/src/main/res/layout/fragment_mypage.xml
@@ -238,7 +238,27 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/MypageInfoLayout"
                 tools:ignore="MissingConstraints" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/Mypage_singup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginTop="100dp"
+                android:layout_marginBottom="32dp"
+                android:layout_weight="1"
+                android:background="#D8B674"
+                android:text="로그인"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/MypageInfoLayout"
+                tools:ignore="MissingConstraints" />
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+
     </ScrollView>
 
 


### PR DESCRIPTION
1.  로그인 화면에서 비회원 로그인 클릭시 홈화면으로 이동
2.  비회원 로그인으로 이용중 커뮤니티 프레그먼트로 들어갈 시 로그인이 필요하다는 다이얼로그 띄우고 확인 클릭시 로그인화면으로 이동(확인 -> 로그인화면으로 이동, 취소 -> 홈프레그먼트로 이동)
3. 비회원 로그인으로 이용중 마이페이지로 이동시 로그아웃이 아닌 로그인이 보이게 하기(로그인 버튼 클릭 시 로그인 화면으로)
close #60 
4. community detail 수정버튼 클릭시 다이얼로그 UI 변경